### PR TITLE
Fix for issue #5

### DIFF
--- a/ep7.ipynb
+++ b/ep7.ipynb
@@ -360,7 +360,7 @@
     }
    ],
    "source": [
-    "weights = classifier.weights_\n",
+    "weights = classifier.get_variable_value("linear//weight")\n",
     "f, axes = plt.subplots(2, 5, figsize=(10,4))\n",
     "axes = axes.reshape(-1)\n",
     "for i in range(len(axes)):\n",


### PR DESCRIPTION
Added fix for the following error on newer TensorFlow versions:
AttributeError: 'LinearClassifier' object has no attribute 'weights_'

Tested on Python 3.5.2 and TensorFlow 1.9.0